### PR TITLE
SCP Fixes

### DIFF
--- a/SourceCode/Events/1048_A.bb
+++ b/SourceCode/Events/1048_A.bb
@@ -23,7 +23,9 @@ Function UpdateEvent_1048_A(e.Events)
 			Case 1
 				Animate2(e\room\Objects[0], AnimTime(e\room\Objects[0]), 2.0, 395.0, 1.0)
 				
-				If (EntityDistanceSquared(Collider, e\room\Objects[0])<PowTwo(2.5)) Then e\EventState = 2
+				If (Not NoTarget) Then
+					If (EntityDistanceSquared(Collider, e\room\Objects[0])<PowTwo(2.5)) Then e\EventState = 2
+				EndIf
 			Case 2
 				Local prevFrame# = AnimTime(e\room\Objects[0]) 
 				Animate2(e\room\Objects[0], prevFrame, 2.0, 647.0, 1.0, False)
@@ -41,7 +43,7 @@ Function UpdateEvent_1048_A(e.Events)
 				RotateEntity(e\room\Objects[0], -90.0, EntityYaw(e\room\Objects[0]), 0.0)
 				
 				If (prevFrame>646.0) Then
-					If (PlayerRoom = e\room) Then
+					If (PlayerRoom = e\room) And (Not GodMode) Then
 						e\EventState = 3	
 						PlaySound_Strict e\Sound2
 						
@@ -83,14 +85,17 @@ Function UpdateEvent_1048_A(e.Events)
 				EndIf
 				
 				If (e\EventState2>70*15) Then
-					Kill()
+					If (Not GodMode) Then
+						Kill()
+					EndIf
+					e\room\Objects[0] = FreeEntity_Strict(e\room\Objects[0])
 					e\EventState = 4
 					RemoveEvent(e)
 				EndIf
 		End Select 
 		
 		If (e <> Null) Then
-			If PlayerRoom <> e\room Then
+			If PlayerRoom <> e\room Or (GodMode) Then
 				If e\EventState3>0 Then
 					e\EventState3 = e\EventState3+FPSfactor
 					

--- a/SourceCode/Main.bb
+++ b/SourceCode/Main.bb
@@ -3612,6 +3612,7 @@ Function LoadEntities()
 	ParticleTextures[8] = LoadTexture_Strict("GFX\particle.png",1+2,2)
 	ParticleTextures[9] = LoadAnimTexture("GFX\fog_textures.png",1+2,256,256,0,4)
 	ParticleTextures[12] = LoadTexture_Strict("GFX\WaterParticle3.png",1+2,2)
+	ParticleTextures[13] = LoadTexture_Strict("GFX\fire_particle.png",1+2,2)
 	
 	SetChunkDataValues()
 	

--- a/SourceCode/NPCs.bb
+++ b/SourceCode/NPCs.bb
@@ -3610,18 +3610,19 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 	
 	Select c_input$ 
 		Case "008", "008zombie"
-			If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
-				CreateConsoleMsg("SCP-008 infected human cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
-			Else
-				If mp_I\Gamemode\ID = Gamemode_Waves Then
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
+					CreateConsoleMsg("SCP-008 infected human cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
+				Else If mp_I\Gamemode\ID = Gamemode_Waves Then
 					n.NPCs = CreateNPC(NPCtypeZombie, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
-				Else	
-					n.NPCs = CreateNPC(NPCtype008, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
 				EndIf
+			Else
+				n.NPCs = CreateNPC(NPCtype008, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
+			EndIf	
+			If n.NPCs <> Null Then
 				n\State = 1
 				consoleMSG = "SCP-008 infected human spawned."
-			EndIf	
-			
+			EndIf
 		Case "049", "scp049", "scp-049"
 			If NTF_GameModeFlag = 3 Then
 				CreateConsoleMsg("SCP-049 cannot be spawned in Multiplayer. Sorry!", 255, 0, 0)
@@ -3632,8 +3633,10 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 			EndIf	
 			
 		Case "049-2", "0492", "scp-049-2", "scp049-2", "049zombie"
-			If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
-				CreateConsoleMsg("SCP-049-2 cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
+					CreateConsoleMsg("SCP-049-2 cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
+				EndIf
 			Else	
 				n.NPCs = CreateNPC(NPCtypeZombie, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
 				n\State = 1
@@ -3697,9 +3700,11 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 			CreateConsoleMsg("SCP-860-2 cannot be spawned with the console. Sorry!", 255, 0, 0)
 			
 		Case "939", "scp939", "scp-939"
-			If mp_I\Gamemode\ID = Gamemode_Waves Then
-				n.NPCs = CreateNPC(NPCtype939, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
-				consoleMSG = "SCP-939 instance spawned."
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Waves Then
+					n.NPCs = CreateNPC(NPCtype939, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
+					consoleMSG = "SCP-939 instance spawned."
+				EndIf
 			Else
 				CreateConsoleMsg("SCP-939 instances cannot be spawned with the console. Sorry!", 255, 0, 0)
 			EndIf
@@ -3713,9 +3718,11 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 			EndIf	
 			
 		Case "1048-a", "scp1048-a", "scp-1048-a", "scp1048a", "scp-1048a"
-			If mp_I\Gamemode\ID = Gamemode_Waves Then
-				n.NPCs = CreateNPC(NPCtype1048a, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
-				consoleMSG = "SCP-1048-a instance spawned."
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Waves Then
+					n.NPCs = CreateNPC(NPCtype1048a, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
+					consoleMSG = "SCP-1048-a instance spawned."
+				EndIf
 			Else
 				CreateConsoleMsg("SCP-1048-A cannot be spawned with the console. Sorry!", 255, 0, 0)
 			EndIf
@@ -3813,9 +3820,11 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 				n\State = 0
 			EndIf	
 		Case "035", "scp-035", "scp035"
-			If mp_I\Gamemode\ID = Gamemode_Waves Then
-				n.NPCs = CreateNPC(NPCtype035, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
-				consoleMSG = "SCP-035 spawned."
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Waves Then
+					n.NPCs = CreateNPC(NPCtype035, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
+					consoleMSG = "SCP-035 spawned."
+				EndIf
 			Else
 				CreateConsoleMsg("SCP-035 cannot be spawned in Singleplayer. Sorry!", 255, 0, 0)
 			EndIf	
@@ -3827,8 +3836,13 @@ Function Console_SpawnNPC(c_input$, c_state$ = "")
 				consoleMSG = "SCP-682 spawned."
 			EndIf	
 		Case "457", "scp-457", "scp457"
-			If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
-				CreateConsoleMsg("SCP-457 cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
+			If mp_I\Gamemode <> Null Then
+				If mp_I\Gamemode\ID = Gamemode_Deathmatch Then
+					CreateConsoleMsg("SCP-457 cannot be spawned in Deathmatch. Sorry!", 255, 0, 0)
+				Else
+					n.NPCs = CreateNPC(NPCtype457, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
+					consoleMSG = "SCP-457 spawned."
+				EndIf
 			Else	
 				n.NPCs = CreateNPC(NPCtype457, EntityX(Collider), EntityY(Collider) + 0.2, EntityZ(Collider))
 				consoleMSG = "SCP-457 spawned."

--- a/SourceCode/NPCs/NPCtype173.bb
+++ b/SourceCode/NPCs/NPCtype173.bb
@@ -279,7 +279,11 @@ Function UpdateNPCtype173(n.NPCs)
 							Else
 								If Rand(400)=1 Then RotateEntity (n\Collider, 0, Rnd(360), 0)
 								TranslateEntity n\Collider,Cos(EntityYaw(n\Collider)+90.0)*n\Speed*FPSfactor,0.0,Sin(EntityYaw(n\Collider)+90.0)*n\Speed*FPSfactor
-								n\Angle = Rnd(-120,120)
+								If (Not NoTarget) Then
+									n\Angle = Rnd(-120,120)
+								Else
+									n\Angle = 0
+								EndIf
 							EndIf
 						EndIf
 					EndIf ; less than 2 rooms away from the player

--- a/SourceCode/NPCs/NPCtype457.bb
+++ b/SourceCode/NPCs/NPCtype457.bb
@@ -56,19 +56,20 @@ Function UpdateNPCtype457(n.NPCs)
 		Select n\State
 			Case SCP457_ATTACK
 				;[Block]
-				If (Not GodMode) Then
+				If (Not GodMode) And (Not NoTarget) Then
 					If psp\Health > 0 Then
 						PlaySound_Strict(LoadTempSound("SFX\SCP\294\burn.ogg"))
 					EndIf
 					Kill()
+					DeathMSG = Designation+". Cause of death: Severe 3rd degree burns across the body. Assumed to be attacked by SCP-457."
 				Else
 					n\State = SCP457_WALK
 				EndIf
 				;[End Block]
 			Case SCP457_WALK
 				;[Block]
-				If dist<20.0 And dist>1.21 Then
-					If EntityVisible(Collider, n\Collider) Then
+				If dist<20.0 And dist>0.5625 Then
+					If EntityVisible(Collider, n\Collider) And (Not NoTarget) Then
 						PointEntity n\obj, Collider
 						RotateEntity n\Collider, 0, CurveAngle(EntityYaw(n\obj), EntityYaw(n\Collider), 30.0), 0
 						
@@ -77,8 +78,14 @@ Function UpdateNPCtype457(n.NPCs)
 						MoveEntity n\Collider, 0, 0, n\CurrSpeed * FPSfactor
 						
 						AnimateNPC(n, 284, 333, n\CurrSpeed)
+					Else
+						v3d_1 = CreateVector3D(334, 494, 0.3)
+						v3d_2 = CreateVector3D(284, 333, 0.43)
+						NPC_GoTo(n, v3d_1, v3d_2, Collider, 1.0)
+						Delete v3d_1
+						Delete v3d_2
 					EndIf
-				ElseIf dist<0.5625 Then
+				ElseIf dist<=0.5625 Then
 					If yaw<=60.0 Then
 						n\State = SCP457_ATTACK
 						n\CurrSpeed = 0

--- a/SourceCode/NPCs/NPCtype939.bb
+++ b/SourceCode/NPCs/NPCtype939.bb
@@ -166,8 +166,10 @@ Function UpdateNPCtype939(n.NPCs)
 								If DistanceSquared(n\EnemyX, EntityX(n\Collider), n\EnemyZ, EntityZ(n\Collider))<PowTwo(1.5) Then
 									PlayNPCSound(n, n\Sound2)
 									;Injuries = Injuries + Rnd(1.5, 2.5)-WearingVest*0.5
-									DamageSPPlayer(Rnd(10.0, 25.0))
-									BlurTimer = 500
+									If (Not GodMode) Then
+										DamageSPPlayer(Rand(35,55))
+										BlurTimer = 500
+									EndIf
 								Else
 									n\Frame	 = 449
 								EndIf


### PR DESCRIPTION
173:
- Head was rotating when NoTarget was on

457:
- Game crash due to missing fire sprite
- 457 still tried to attack you while NoTarget was on (also could not really go near you)

939:
- Depletes health and armor in GodMode when attacking
- Deals more damage (to make it consistent with MP)

1048-A:
- NoTarget started the event when it shouldn't
- GodMode would kill you after the event started and you got infected

General:
- Spawning certain SCP's triggered a check that referenced a "Null" object, crashing the game