### PR TITLE
Fix injure command

### DIFF
--- a/SourceCode/Console.bb
+++ b/SourceCode/Console.bb
@@ -464,6 +464,10 @@ Function UpdateConsole(commandSet%)
 							StrTemp$ = Lower(Right(ConsoleInput, Len(ConsoleInput) - Instr(ConsoleInput, " ")))
 							
 							psp\Health = psp\Health - Float(StrTemp)
+							If psp\Health <= 0 Then
+								Kill()
+							EndIf
+							CreateConsoleMsg("Injured the player for " + Int(StrTemp) + " HP")
 							;[End Block]
 						Case "infect"
 							;[Block]


### PR DESCRIPTION
Description:
- A pull request that fixes the injure command causing animation locks if the users HP goes below 0

Changes:
- Console.bb includes a check for the users health when the "injure" command is run and kills the user if it goes below 0