### PR TITLE
Added EZ Tesla Gates to spawn again

### DIFF
--- a/Data/rooms.ini
+++ b/Data/rooms.ini
@@ -660,12 +660,12 @@ shape = 2
 commonness = 30
 zone1=EZ
 
-;[room2_tesla_ez]
-;descr=Hallway with a tesla gate. EZ variant.
-;mesh=room2tesla_opt.rmesh
-;shape = 2
-;commonness = 30
-;zone1=EZ
+[room2_tesla_ez]
+descr=Hallway with a tesla gate. EZ variant.
+mesh=room2tesla_opt.rmesh
+shape = 2
+commonness = 30
+zone1=EZ
 
 [room3_servers_1]
 descr=A maze of re-arranced servers, where SCP-173 spawns.


### PR DESCRIPTION
 uncommented the line preventing Tesla Gates from spawning in the Entrance Zone just like they do in SCP:CB.